### PR TITLE
add nix build script

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,16 @@
+name: "Build"
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: cachix/install-nix-action@v10
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - run: nix-build

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ cmake-build-*/
 .ccls-cache/
 .gdb_history
 compile_commands.json
+
+# nix stuff
+**/result

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project(ImageGraph)
 option(BUILD_EXAMPLE "Build Examples" ON)
 option(BUILD_TEST "Build Tests" ON)
 
+add_subdirectory(libs/pcg-cpp)
+include_directories(${PROJECT_SOURCE_DIR}/libs/pcg-cpp/include)
+
 add_library(ImageGraph SHARED)
 
 # C++ Standard Version and Compiler settings.
@@ -34,8 +37,7 @@ find_package(Threads REQUIRED)
 target_link_libraries(ImageGraph PUBLIC Threads::Threads)
 
 # Threading Building Blocks
-find_package(TBB REQUIRED)
-target_link_libraries(ImageGraph PUBLIC TBB::tbb)
+target_link_options(ImageGraph PUBLIC "-ltbb")
 
 # PCG is now used through a relative path.
 

--- a/cmake/ImageGraphConfig.cmake.in
+++ b/cmake/ImageGraphConfig.cmake.in
@@ -6,7 +6,7 @@ find_dependency(Boost COMPONENTS context REQUIRED)
 find_dependency(PkgConfig REQUIRED)
 pkg_check_modules(VIPS REQUIRED IMPORTED_TARGET vips vips-cpp gobject-2.0)
 find_dependency(Threads REQUIRED)
-find_dependency(TBB REQUIRED)
+#find_dependency(TBB REQUIRED)
 find_dependency(absl REQUIRED)
 
 if(NOT TARGET ImageGraph::ImageGraph)

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,36 @@
+with import <nixpkgs> {};
+
+
+(overrideCC stdenv clang_9).mkDerivation {
+  name = "st16sim";
+
+  src = ./.;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
+
+  postInstall = ''
+    cp -R ../dependencies $out/include/
+  '';
+
+  buildInputs = [
+    abseil-cpp
+    boost.dev
+    fftw.dev
+    glib.dev
+    gsl
+    imagemagick.dev
+    libexif
+    libgsf.dev
+    openexr.dev
+    orc.dev
+    pcg_c
+    pcre.dev
+    tbb
+    vips
+  ];
+}

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@ with import <nixpkgs> {};
 
 
 (overrideCC stdenv clang_9).mkDerivation {
-  name = "st16sim";
+  name = "ImageGraph";
 
   src = ./.;
 


### PR DESCRIPTION
Hi, I created a nix expression to build this. This includes the packaging of your modified `pcg` version. However, on `pcg`, a small modification was necessary to make it build:

```
diff --git a/CMakeLists.txt b/CMakeLists.txt
index de2dce4..39064f9 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if(BUILD_SAMPLE)
   add_subdirectory(sample)
 endif()
 if(BUILD_TEST)
-  add_subdirectory(test-high)
+  #add_subdirectory(test-high)
 endif()

 include(GNUInstallDirs)
```

If this change is not made, the build stops with this output:

```
CMake Error at libs/pcg-cpp/CMakeLists.txt:18 (add_subdirectory):
  The source directory

    /build/ImageGraph/libs/pcg-cpp/test-high

  does not contain a CMakeLists.txt file.
```